### PR TITLE
Add .run domain

### DIFF
--- a/src/components/cards/providers/Domains.tsx
+++ b/src/components/cards/providers/Domains.tsx
@@ -37,6 +37,7 @@ const DomainCard: React.FC<{query: string}> = ({query}) => {
     `${lowerCase}.tools`,
     `${lowerCase}.design`,
     `${lowerCase}.build`,
+    `${lowerCase}.run`,
     `get${lowerCase}.com`,
   ];
 


### PR DESCRIPTION
Might be a bit obscure, but the `.run` domain has been growing in popularity for npm packages or CLI programs.