### PR TITLE
fix(producthunt): prepend producthunt.com to URL

### DIFF
--- a/src/components/cards/providers/ProductHunt.tsx
+++ b/src/components/cards/providers/ProductHunt.tsx
@@ -29,7 +29,7 @@ const Search: React.FC<{ query: string }> = ({ query }) => {
             <Result
               title={hit.name}
               message={`${hit.tagline} (⬆️ ${hit.vote_count})`}
-              link={hit.url}
+              link={`https://www.producthunt.com${hit.url}`}
               icon={<FaProductHunt />}
               key={hit.id}
             />


### PR DESCRIPTION
Clicking posts in the Product Hunt card will go to `https://namae.dev/posts/namae` instead of Product Hunt since the Algolia results don't have the domain:
```
"url": "/posts/namae",
```