### PR TITLE
Remove unnecessary ternary expression in whois lookup

### DIFF
--- a/api/services/domain/[query].ts
+++ b/api/services/domain/[query].ts
@@ -20,7 +20,7 @@ export default async function handler(
       throw new Error(`Got error while querying for ${query}: ${first.error}`);
     }
     try {
-      const availability = first['Domain Status'].length > 0 ? false : true;
+      const availability = first['Domain Status'].length == 0;
       send(res, { availability });
     } catch (err) {
       console.log(response);


### PR DESCRIPTION
This minor PR cleans a ternary expression into a simple comparison for improved clarity, as it's easier to understand what logic is being followed this way, rather than having to try and work out a ternary in your head, and also because the result of the comparison is already a boolean value it makes sense to use that value directly.