### PR TITLE
refactor(YouTube): use channel handles

### DIFF
--- a/src/components/cards/providers/YouTube.tsx
+++ b/src/components/cards/providers/YouTube.tsx
@@ -22,10 +22,10 @@ const YouTubeCard: React.FC<{ query: string }> = ({ query }) => {
       <Repeater items={names} moreItems={moreNames}>
         {(name) => (
           <DedicatedAvailability
-            name={`youtube.com/c/${name}`}
+            name={`youtube.com/@${name}`}
             service="existence"
-            message={`Go to youtube.com/c/${name}`}
-            link={`https://www.youtube.com/c/${name}`}
+            message={`Go to youtube.com/@${name}`}
+            link={`https://www.youtube.com/@${name}`}
             icon={<FaYoutube />}
           />
         )}


### PR DESCRIPTION
This makes the YouTube component use [Channel Handles](https://blog.youtube/news-and-events/introducing-handles-a-new-way-to-identify-your-youtube-channel/) instead of Channel URLs.

YouTube no longer allows channels to change their URLs as of then, however your handle can be anything, so this will allow the user to look more into what handles they can use instead of Channel URLs since they will not be able to change their own.

