### PR TITLE
fix(reddit): fix availibility check

### DIFF
--- a/api/services/reddit/[query].ts
+++ b/api/services/reddit/[query].ts
@@ -19,7 +19,7 @@ export default async function handler(
     const response = await fetch(`https://reddit.com/r/${query}`, 'GET');
     const body = await response.text();
     const availability = body.includes(
-      'Sorry, there aren’t any communities on Reddit with that name.'
+      'Community not found'
     );
     send(res, { availability });
   } catch (err: any) {


### PR DESCRIPTION
Changes the text to check for on Reddit as 'Sorry there aren't any communities on Reddit with that name.' is an old message (which can be found at https://new.reddit.com/r/invalidsubreddit), the current message is 'Community not found', as seen on https://www.reddit.com/r/invalidsubreddit/
![image](https://github.com/user-attachments/assets/50292381-fc8e-4620-a80b-2c5fd9b2f3d0)

![image](https://github.com/user-attachments/assets/3abd3e2f-b64e-4454-ad33-f3437beb263b)
